### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,7 +14,7 @@ AFArray	KEYWORD1
 
 add	KEYWORD2
 find KEYWORD2
-to_array KEYWORD2
+to_array	KEYWORD2
 reset	KEYWORD2
 size	KEYWORD2
 is_full	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the to_array keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords