### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -27,7 +27,7 @@ reset	KEYWORD2
 size	KEYWORD2
 is_full	KEYWORD2
 is_valid_index	KEYWORD2
-get_from_indexes  KEYWORD2
+get_from_indexes	KEYWORD2
 slice	KEYWORD2
 has_next	KEYWORD2
 next	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords